### PR TITLE
Several bugfixes and improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,17 @@
   "keywords": [
     "node",
     "env",
-    "basic-auth"
+    "basic-auth",
+    "basic",
+    "auth",
+    "express"
   ],
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "author": "Jan Nahody <jan.nahody@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "basic-auth": "^1.0.3",
-    "lodash": "^3.10.1"
+    "basic-auth": "^1.0.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,8 @@ By default the prefix for username is `basicauth_user` and for password `basicau
 To add multiple users, add an additional idententication string to parameter name. This additional string 
 must be same for username and password. 
 
+Works in Node.js v4+ with the `--harmony` flag, or Node.js v6+ without any flags.
+
 ### Example
 ```shell
 export basicauth_user = user1
@@ -30,12 +32,15 @@ export basicauth_password_mike = secret
 ## Usage
 ```js
 // Initialize nodenv-basic-auth
-var NodenvBasicAuth = require('nodenv-basic-auth');
-var auth = new NodenvBasicAuth();
-// enable auth on route
+var auth = require('nodenv-basic-auth')();
+
+// EITHER use auth on specific routes
 app.get('/home', auth, function(req, res) {
  res.send('Hello World');
 });
+
+// OR use it site-wide
+app.use(auth);
 ```
 
 ## Extend usage
@@ -54,7 +59,7 @@ Environment postfix to identify password. Default `basicauth_pass`
 ## Users
 Object to transmit user credentials:
 ```js
-var defaultUsers = {
+var users = {
   mike: 'secret',
   john: 'secret',
   ... 


### PR DESCRIPTION
Hi, I like the idea behind this package, but ran into several issues when I tried to actually use it. All are fixed in this PR:
1. The class name had a typo: `NodenvBasicAuth` should have been `NodeEnvBasicAuth`
2. The `forEach` loop in `dispatchEnv()` method was missing it's context
3. The check at the start of `register()` had several issues
   - It's hardcoded to a different value than the default prefix (`basicauth_name` rather than `basicauth_user`)
   - It doesn't respect the configured prefix values
   - If it is going to be there, it should probably just check that `this.users.length > 0` which would solve the first two issues, but...
   - I'd argue that it shouldn't be there at all: If I enable the plugin but don't configure any usernames and passwords, then I would expect it to just reject all requests, and perhaps log a warning. (This could be moved to the `dispatchEnv()` method, though so that it would only run once.) I removed it but did not add any warning.
4. Caching results in `this.auth` was troublesome because unless you create a new instance for every single request, the credentials that happen to come with the first request will be used for ever subsequent request, even from other users. The `basic-auth` package is fast and recommends that you just run it again for every single request, so that's what I did.
5. Calls to `this.unauthorized(res);` didn't work because `unauthorized` is declared `static`. Changed to `NodeEnvBasicAuth.unauthorized(res);` instead.
6. The `options` object passed into the constructor was getting ignored.
7. Merging the `users` option was unnecessary. With that and 3), we can drop the lodash dependency.
8. The readme indicates that you should pass the `auth` instance directly to express when you should actually pass in the `auth.register` method, BUT, even that isn't enough because it looses it's context. I changed module.exports to a function that just returns a pre-bound reference to this register method rather than the class instance so that the example in the readme would actually work. (It also works without `new` that way).
